### PR TITLE
name has changed from electron-quick-start-ts to electron-quick-start-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "electron-quick-start-ts",
+  "name": "electron-quick-start-typescript",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
name has changed from `electron-quick-start-ts` to `electron-quick-start-typescript`