### PR TITLE
Bugfix for the "%APPDATA%" folder name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "electron-quick-start-typescript",
   "version": "1.0.0",
   "description": "A minimal Electron application written with Typescript",
+  "main": "./dist/main.js",
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "start": "npm run build && electron ./dist/main.js"
+    "start": "npm run build && electron ."
   },
   "repository": "https://github.com/electron/electron-quick-start-typescript",
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "noImplicitAny": true,
     "sourceMap": true,
-    "outDir": "dist",
+    "outDir": "./dist",
     "baseUrl": ".",
     "paths": {
       "*": ["node_modules/*"]


### PR DESCRIPTION
(without this fix, your AppData will be in the "%APPDATA%\Electron" folder, instead of "%APPDATA%\{APPNAME_FROM_PACKAGE_JSON}")