### PR TITLE
Don't show dev tools by default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,18 +6,18 @@ let mainWindow: Electron.BrowserWindow;
 function createWindow() {
   // Create the browser window.
   mainWindow = new BrowserWindow({
+    width: 800,
     height: 600,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
     },
-    width: 800,
   });
 
   // and load the index.html of the app.
   mainWindow.loadFile(path.join(__dirname, "../index.html"));
 
   // Open the DevTools.
-  mainWindow.webContents.openDevTools();
+  // mainWindow.webContents.openDevTools();
 
   // Emitted when the window is closed.
   mainWindow.on("closed", () => {


### PR DESCRIPTION
1. make width and height properties more readable
2. don't open dev tools by default (same behaviour as https://github.com/electron/electron-quick-start)