### PR TITLE
Bugfix for the preload.ts reference in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ function createWindow() {
   const mainWindow = new BrowserWindow({
     height: 600,
     webPreferences: {
-      preload: path.join(__dirname, "preload.js"),
+      preload: path.join(__dirname, "preload.ts"),
     },
     width: 800,
   });


### PR DESCRIPTION
The main.ts file currently references `preload.js`, which doesn't exist. I changed this to `preload.ts`.