### PR TITLE
Fix: preload.ts has a type error

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -8,7 +8,7 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   };
 
-  for (const type of ["chrome", "node", "electron"]) {
-    replaceText(`${type}-version`, process.versions[type as keyof NodeJS.ProcessVersions]);
+  for (const type of ["chrome", "node", "electron"] as const) {
+    replaceText(`${type}-version`, process.versions[type]);
   }
 });


### PR DESCRIPTION
Fix typescript error: ```Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.```