### PR TITLE
refactor: use whenReady() instead of .on("ready")

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ function createWindow() {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on("ready", () => {
+app.whenReady().then(() => {
   createWindow();
 
   app.on("activate", function () {


### PR DESCRIPTION
electron/electron-quick-start is already use app.whenReady().then instead of app.on('ready') the year before. [electron/electron@bfe7da]
Related pull request is merged here. [electron/electron-quick-start#21972]